### PR TITLE
Honors ports on the host page

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ var proxyOrigin = 'https://public-api.wordpress.com';
  * "Origin" of the current HTML page.
  */
 
-var origin = window.location.protocol + '//' + window.location.hostname;
+var origin = window.location.protocol + '//' + window.location.host;
 debug('using "origin": %o', origin);
 
 /**


### PR DESCRIPTION
Switches window.location.hostname to window.location.host so we can support a url like example.local:3000
