### PR TITLE
IE9 do not send objects

### DIFF
--- a/dist/wpcom-proxy-request.js
+++ b/dist/wpcom-proxy-request.js
@@ -38,14 +38,17 @@ debug('using "origin": %o', origin);
  * https://github.com/Modernizr/Modernizr/issues/388#issuecomment-31127462
  */
 
-var postStrings = false;
-try {
-  window.postMessage({
-    toString: function () {
-      postStrings = true;
-    }
-  },"*");
-} catch (e) {}
+var postStrings = (function (){
+  var r = false;
+  try {
+    window.postMessage({
+      toString: function () {
+        r = true;
+      }
+    },"*");
+  } catch (e) {}
+  return r;
+})();
 
 /**
  * Reference to the <iframe> DOM element.
@@ -361,7 +364,7 @@ function onmessage (e) {
   var data = e.data;
   if (!data) return debug('no `data`, bailing');
 
-  if ('string' === typeof data && postStrings) {
+  if (postStrings && 'string' === typeof data) {
     data = JSON.parse(data);
   }
 

--- a/dist/wpcom-proxy-request.js
+++ b/dist/wpcom-proxy-request.js
@@ -29,6 +29,25 @@ var origin = window.location.protocol + '//' + window.location.host;
 debug('using "origin": %o', origin);
 
 /**
+ * Detecting support for the structured clone algorithm. IE8 and 9, and Firefox
+ * 6.0 and below only support strings as postMessage's message. This browsers
+ * will try to use the toString method.
+ *
+ * https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
+ * https://developer.mozilla.org/en-US/docs/Web/Guide/API/DOM/The_structured_clone_algorithm
+ * https://github.com/Modernizr/Modernizr/issues/388#issuecomment-31127462
+ */
+
+var postStrings = false;
+try {
+  window.postMessage({
+    toString: function () {
+      postStrings = true;
+    }
+  },"*");
+} catch (e) {}
+
+/**
  * Reference to the <iframe> DOM element.
  * Gets set in the install() function.
  */
@@ -154,7 +173,7 @@ function submitRequest (params) {
     postAsArrayBuffer(params);
   } else {
     try {
-      iframe.contentWindow.postMessage(JSON.stringify(params), proxyOrigin);
+      iframe.contentWindow.postMessage(postStrings ? JSON.stringify(params) : params, proxyOrigin);
     } catch (e) {
       // were we trying to serialize a `File`?
       if (hasFile(params)) {
@@ -342,7 +361,7 @@ function onmessage (e) {
   var data = e.data;
   if (!data) return debug('no `data`, bailing');
 
-  if ( 'string' === typeof data ) {
+  if ('string' === typeof data && postStrings) {
     data = JSON.parse(data);
   }
 

--- a/index.js
+++ b/index.js
@@ -360,7 +360,7 @@ function onmessage (e) {
   var data = e.data;
   if (!data) return debug('no `data`, bailing');
 
-  if ('string' === typeof data && postStrings) {
+  if (postStrings && 'string' === typeof data) {
     data = JSON.parse(data);
   }
 

--- a/index.js
+++ b/index.js
@@ -28,6 +28,25 @@ var origin = window.location.protocol + '//' + window.location.host;
 debug('using "origin": %o', origin);
 
 /**
+ * Detecting support for the structured clone algorithm. IE8 and 9, and Firefox
+ * 6.0 and below only support strings as postMessage's message. This browsers
+ * will try to use the toString method.
+ *
+ * https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
+ * https://developer.mozilla.org/en-US/docs/Web/Guide/API/DOM/The_structured_clone_algorithm
+ * https://github.com/Modernizr/Modernizr/issues/388#issuecomment-31127462
+ */
+
+var postStrings = false;
+try {
+  window.postMessage({
+    toString: function () {
+      postStrings = true;
+    }
+  },"*");
+} catch (e) {}
+
+/**
  * Reference to the <iframe> DOM element.
  * Gets set in the install() function.
  */
@@ -153,7 +172,7 @@ function submitRequest (params) {
     postAsArrayBuffer(params);
   } else {
     try {
-      iframe.contentWindow.postMessage(JSON.stringify(params), proxyOrigin);
+      iframe.contentWindow.postMessage(postStrings ? JSON.stringify(params) : params, proxyOrigin);
     } catch (e) {
       // were we trying to serialize a `File`?
       if (hasFile(params)) {
@@ -341,7 +360,7 @@ function onmessage (e) {
   var data = e.data;
   if (!data) return debug('no `data`, bailing');
 
-  if ( 'string' === typeof data ) {
+  if ('string' === typeof data && postStrings) {
     data = JSON.parse(data);
   }
 

--- a/index.js
+++ b/index.js
@@ -153,7 +153,7 @@ function submitRequest (params) {
     postAsArrayBuffer(params);
   } else {
     try {
-      iframe.contentWindow.postMessage(params, proxyOrigin);
+      iframe.contentWindow.postMessage(JSON.stringify(params), proxyOrigin);
     } catch (e) {
       // were we trying to serialize a `File`?
       if (hasFile(params)) {
@@ -340,6 +340,10 @@ function onmessage (e) {
 
   var data = e.data;
   if (!data) return debug('no `data`, bailing');
+
+  if ( 'string' === typeof data ) {
+    data = JSON.parse(data);
+  }
 
   // check if we're receiving a "progress" event
   if (data.upload || data.download) {

--- a/index.js
+++ b/index.js
@@ -37,14 +37,17 @@ debug('using "origin": %o', origin);
  * https://github.com/Modernizr/Modernizr/issues/388#issuecomment-31127462
  */
 
-var postStrings = false;
-try {
-  window.postMessage({
-    toString: function () {
-      postStrings = true;
-    }
-  },"*");
-} catch (e) {}
+var postStrings = (function (){
+  var r = false;
+  try {
+    window.postMessage({
+      toString: function () {
+        r = true;
+      }
+    },"*");
+  } catch (e) {}
+  return r;
+})();
 
 /**
  * Reference to the <iframe> DOM element.


### PR DESCRIPTION
On the notifications client we are hitting a IE9 limitation when sending messages using `rest-proxy`. IE8/9 only support strings, and this forces a JSON string for `postMessage` and `onmessage` to circumvent that limitation.

Reference: http://caniuse.com/#feat=x-doc-messaging

This fixes https://github.com/Automattic/notifications-client/issues/401