### PR TITLE
Fix TypeError on string body 'error' from rest-proxy

### DIFF
--- a/index.js
+++ b/index.js
@@ -401,7 +401,7 @@ function onmessage (e) {
     debug('got %o status code for URL: %o', statusCode, xhr.params.path);
   }
 
-  if (body && headers) {
+  if (typeof body === 'object' && headers) {
     body._headers = headers;
   }
 


### PR DESCRIPTION
This bug caused connection errors to be dropped because the resolve function was not reached. Seems like #5.