### PR TITLE
Version-bump `wp-error`

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "debug": "~2.2.0",
     "progress-event": "~1.0.0",
     "uid": "0.0.2",
-    "wp-error": "^1.0.0"
+    "wp-error": "^1.3.0"
   }
 }


### PR DESCRIPTION
Version 1.3.0 of `wp-error` introduces a fix to prevent throwing a `TypeError` when null or undefined values are passed into the `WPError()` constructor.