### PR TITLE
Fix statusCode for wp-api requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -462,6 +462,8 @@ function onmessage( e ) {
 			statusCode = body.data.status;
 			delete body.code;
 			delete body.data;
+		} else {
+			statusCode = 200;
 		}
 	}
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "prepublish": "make build"
   },
-  "version": "4.0.2",
+  "version": "4.0.3",
   "author": "Automattic, Inc.",
   "contributors": [
     "Damian Suarez <rdsuarez@gmail.com>",


### PR DESCRIPTION
`statusCode` is never set for wp-api requests and this causes those requests to be considered as faulty.
We now default to statusCode 200 when no error is detected.

Test this change on wp-calypso. See https://github.com/Automattic/wp-calypso/pull/16447