### PR TITLE
Bump to 4.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "prepublish": "make build"
   },
-  "version": "4.0.3",
+  "version": "4.0.4",
   "author": "Automattic, Inc.",
   "contributors": [
     "Damian Suarez <rdsuarez@gmail.com>",


### PR DESCRIPTION
This is an addendum to #25 because apparently 4.0.3 already existed in npm.