### PR TITLE
Unbind window.message when uninstalling

### DIFF
--- a/index.js
+++ b/index.js
@@ -359,6 +359,7 @@ const reloadProxy = () => {
  */
 function uninstall() {
 	debug( 'uninstall()' );
+	event.unbind( window, 'message', onmessage );
 	document.body.removeChild( iframe );
 	loaded = false;
 	iframe = null;


### PR DESCRIPTION
This should prevent us from leaking message listeners on an iframe reload.