### PR TITLE
Bump to 4.0.6 and add blowery to contribs

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,13 +12,14 @@
   "scripts": {
     "prepublish": "make build"
   },
-  "version": "4.0.5",
+  "version": "4.0.6",
   "author": "Automattic, Inc.",
   "contributors": [
     "Damian Suarez <rdsuarez@gmail.com>",
     "Nathan Rajlich <nathan@automattic.com>",
     "Andy Skelton <andy@automattic.com>",
-    "Gary Pendergast <gary@pento.net>"
+    "Gary Pendergast <gary@pento.net>",
+    "Ben Lowery <blowery@automattic.com>"
   ],
   "files": [
     "build",


### PR DESCRIPTION
This is to get https://github.com/Automattic/wpcom-proxy-request/pull/30 out into the world