### PR TITLE
Drop support for string argument

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -26,7 +26,7 @@ $ npm install wpcom-proxy-request
 // Import wpcom-proxy-request handler
 import proxy from 'wpcom-proxy-request';
 
-proxy( '/me', function( err, body, headers ) {
+proxy( { path: '/me' }, function( err, body, headers ) {
   if (err) {
     throw err;
   }

--- a/index.js
+++ b/index.js
@@ -100,7 +100,12 @@ debug( 'using "origin": %o', origin );
  * @api public
  */
 const request = ( originalParams, fn ) => {
-	let params = Object.assign( {}, originalParams );
+	let params;
+	if ( 'string' === typeof originalParams ) {
+		params = { path: originalParams };
+	} else {
+		params = Object.assign( {}, originalParams );
+	}
 
 	debug( 'request(%o)', params );
 
@@ -109,9 +114,6 @@ const request = ( originalParams, fn ) => {
 		install();
 	}
 
-	if ( 'string' === typeof params ) {
-		params = { path: params };
-	}
 
 	// generate a uid for this API request
 	const id = uid();

--- a/index.js
+++ b/index.js
@@ -94,18 +94,13 @@ debug( 'using "origin": %o', origin );
  * takes care of WordPress.com user authentication (via the currently
  * logged-in user's cookies).
  *
- * @param {Object|String} originalParams - request parameters
+ * @param {Object} originalParams - request parameters
  * @param {Function} [fn] - callback response
  * @return {XMLHttpRequest} XMLHttpRequest instance
  * @api public
  */
 const request = ( originalParams, fn ) => {
-	let params;
-	if ( 'string' === typeof originalParams ) {
-		params = { path: originalParams };
-	} else {
-		params = Object.assign( {}, originalParams );
-	}
+	let params = Object.assign( {}, originalParams );
 
 	debug( 'request(%o)', params );
 

--- a/test/index.js
+++ b/test/index.js
@@ -95,23 +95,6 @@ runs.forEach( ( { shouldReloadProxy } ) => {
 							done();
 						} );
 					} );
-
-					it( '[v1] should get `me` user with path string', done => {
-						proxy( '/me', ( error, body, headers ) => {
-							// error
-							expect( error ).to.be.an( 'null' );
-
-							// body
-							expect( body.ID ).to.be.ok;
-							expect( body.ID ).to.be.a( 'number' );
-							expect( body.username ).to.be.ok;
-
-							// headers
-							expect( headers ).to.be.ok;
-
-							done();
-						} );
-					} );
 				} );
 
 				describe( 'wrong requests', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -95,6 +95,23 @@ runs.forEach( ( { shouldReloadProxy } ) => {
 							done();
 						} );
 					} );
+
+					it( '[v1] should get `me` user with path string', done => {
+						proxy( '/me', ( error, body, headers ) => {
+							// error
+							expect( error ).to.be.an( 'null' );
+
+							// body
+							expect( body.ID ).to.be.ok;
+							expect( body.ID ).to.be.a( 'number' );
+							expect( body.username ).to.be.ok;
+
+							// headers
+							expect( headers ).to.be.ok;
+
+							done();
+						} );
+					} );
 				} );
 
 				describe( 'wrong requests', () => {


### PR DESCRIPTION
Docs and some code suggest the following should be accepted:

```js
proxy( '/me' );
```

However, a change in 80e1b9a688f286520603a327d71b6b48048c1bc0 introduced a regression where this fails and we must use the params object format:

```js
proxy( { path: '/me' } );
```

Since this is several years old and appears to be a broken feature in at least 1 major release, let's remove support for the string argument.

This PR contains commits to (in order):
- Add failing test
- Fix the failing test
- Remove the feature and the previous changes

Some tests are in a failing state initially. To see the tests, follow the instructions in the Readme, roughly:

- `bash -c "make watch-test-app & make run-test-app & wait"`
- Open http://calypso.localhost:3001/ in your browser